### PR TITLE
Add generator `duplication_divergence_graph`.

### DIFF
--- a/cygraph/generators.pyx
+++ b/cygraph/generators.pyx
@@ -1,0 +1,53 @@
+from .graph cimport Graph, node_t, node_set_t
+from .libcpp.random cimport bernoulli_distribution, mt19937, random_device
+from libcpp.utility cimport move
+import numbers
+from .util import assert_interval
+
+
+cdef class RandomEngine:
+    cdef mt19937 instance
+
+    def __init__(self, seed: int = None):
+        cdef random_device rd
+        if seed is None:
+            self.instance = mt19937(rd())
+        else:
+            self.instance = mt19937(seed)
+
+    def __call__(self):
+        return self.instance()
+
+
+DEFAULT_RANDOM_ENGINE = RandomEngine()
+
+
+cpdef RandomEngine get_random_engine(engine_seed_or_none: int = None):
+    if engine_seed_or_none is None:
+        return DEFAULT_RANDOM_ENGINE
+    elif isinstance(engine_seed_or_none, RandomEngine):
+        return engine_seed_or_none
+    else:
+        return RandomEngine(engine_seed_or_none)
+
+
+def duplication_divergence_graph(n: int, p: float, graph: Graph = None,
+                                 random_engine: RandomEngine = None) -> Graph:
+    cdef bernoulli_distribution retention_dist = bernoulli_distribution(p)
+    assert_interval("p", p, 0, 1)
+    assert_interval("n", n, 2, None)
+    random_engine = get_random_engine(random_engine)
+
+    if not graph:
+        graph = Graph()
+        graph.add_edge(0, 1)
+
+    while graph.number_of_nodes() < n:
+        i = graph.number_of_nodes()
+        # Choose a random node from current graph to duplicate.
+        random_node = random_engine.instance() % i
+        # Duplicate links independently with the given probability.
+        for neighbor in graph._adjacency_map[random_node]:
+            if retention_dist(random_engine.instance):
+                graph.add_edge(i, neighbor)
+    return graph

--- a/cygraph/libcpp/random.pxd
+++ b/cygraph/libcpp/random.pxd
@@ -1,0 +1,39 @@
+from libc.stdint cimport uint_fast32_t
+
+
+cdef extern from "<random>" namespace "std" nogil:
+    cdef cppclass mt19937:
+        ctypedef uint_fast32_t result_type
+
+        mt19937() except +
+        mt19937(result_type seed) except +
+        result_type operator()() except +
+        result_type min() except +
+        result_type max() except +
+        void discard(size_t z) except +
+        void seed(result_type seed) except +
+
+    cdef cppclass random_device:
+        ctypedef uint_fast32_t result_type
+        random_device() except +
+        result_type operator()() except +
+
+    cdef cppclass poisson_distribution[T]:
+        poisson_distribution() except +
+        poisson_distribution(double) except +
+        T operator()[Generator](Generator&) except +
+
+    cdef cppclass binomial_distribution[T]:
+        binomial_distribution() except +
+        binomial_distribution(T, double) except +
+        T operator()[Generator](Generator&) except +
+
+    cpdef cppclass uniform_int_distribution[T]:
+        uniform_int_distribution() except +
+        uniform_int_distribution(T, T) except +
+        T operator()[Generator](Generator&) except +
+
+    cdef cppclass bernoulli_distribution:
+        bernoulli_distribution() except +
+        bernoulli_distribution(double) except +
+        bint operator()[Generator](Generator&) except +

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,16 @@
+from cygraph import generators
+
+
+def test_random_engine():
+    engine = generators.get_random_engine()
+    assert isinstance(engine, generators.RandomEngine)
+    assert isinstance(engine(), int)
+    engine = generators.get_random_engine(3)
+    assert engine() == 2365658986
+    assert generators.get_random_engine(engine) is engine
+
+
+def test_duplication_divergence():
+    graph = generators.duplication_divergence_graph(100, .3)
+    assert graph.number_of_nodes() == 100
+    assert all(k for _, k in graph.degree)


### PR DESCRIPTION
```python
>>> %timeit nx.duplication_divergence_graph(1000, 0.2)
9.09 ms ± 79.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
>>> %timeit cygraph.generators.duplication_divergence_graph(1000, 0.2)
575 µs ± 1.45 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

Interestingly, the networkx generator discards candidate nodes that end up disconnected. Assuming the initial graph is connected, that guarantees that the entire graph is connected.