### PR TITLE
Setup to allow `cimport` from third-party source.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('test_requirements.txt') }}-cimport
       - name: Install package
         run: |
           pip install `cat test_requirements.txt | grep cython==`

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,17 @@ jobs:
         run: make lint
       - name: Build the documentation
         run: make docs doctests
+  cimport-test:
+    name: cimport Test
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+      - name: Install package
+        run: |
+          pip install `cat test_requirements.txt | grep cython==`
+          pip install .
+      - name: cimport Test
+        run: make import_tests

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ workspace/
 
 cygraph/*.cpp
 cygraph/*.html
+tests/test.cpp
+tests/test.html

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *.pxd

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ requirements.txt : requirements.in setup.py test_requirements.txt
 
 test_requirements.txt : test_requirements.in setup.py
 	pip-compile -v -o $@ $<
+
+import_tests :
+	cd tests && cythonize -af3 test.pyx

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ exclude_lines =
 
 [coverage:run]
 plugins = Cython.Coverage
+
+[options]
+include_package_data = True

--- a/tests/test.pyx
+++ b/tests/test.pyx
@@ -1,0 +1,4 @@
+# distutils: language = c++
+
+from cygraph cimport graph
+from cygraph.graph cimport Graph


### PR DESCRIPTION
This PR ensures that third-party source code can still `cimport` the `Graph`, allowing others to develop fast graph generators.