### PR TITLE
Add compile-time variable `DEBUG_LOGGING`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ env:
   SEED: "0"
   # Required for cython coverage checks.
   CYTHON_TRACE: "1"
+  # To facilitate debugging without having an interactive cython debugger.
+  DEBUG_LOGGING: "1"
 
 jobs:
   build:

--- a/cygraph/__init__.py
+++ b/cygraph/__init__.py
@@ -1,1 +1,7 @@
 from .graph import Graph  # noqa: F401
+try:
+    from .graph import LOGGER
+    DEBUG_LOGGING = True
+    del LOGGER
+except ImportError:
+    DEBUG_LOGGING = False

--- a/cygraph/__init__.py
+++ b/cygraph/__init__.py
@@ -1,7 +1,7 @@
 from .graph import Graph  # noqa: F401
-try:
+try:  # pragma: no cover
     from .graph import LOGGER
     DEBUG_LOGGING = True
     del LOGGER
-except ImportError:
+except ImportError:  # pragma: no cover
     DEBUG_LOGGING = False

--- a/cygraph/graph.pyx
+++ b/cygraph/graph.pyx
@@ -1,6 +1,10 @@
 from cython.operator cimport dereference, preincrement
 import numbers
 
+IF DEBUG_LOGGING:
+    import logging
+    LOGGER = logging.getLogger()
+
 
 cdef class Graph:
     def __init__(self):
@@ -56,6 +60,8 @@ cdef class Graph:
     cpdef int add_node(self, node_t node):
         # Using [node] implicitly creates the node, but we don't know whether it existed before.
         self._adjacency_map[node]
+        IF DEBUG_LOGGING:
+            LOGGER.info("added node %d", node)
 
     cpdef int add_nodes_from(self, node_set_t nodes):
         cdef node_t node
@@ -74,6 +80,8 @@ cdef class Graph:
     cpdef int remove_node(self, node_t node) except -1:
         if not self._remove_node(node):
             raise KeyError(f"node {node} does not exist")
+        IF DEBUG_LOGGING:
+            LOGGER.info("removed node %d", node)
 
     cpdef int remove_nodes_from(self, node_set_t nodes):
         cdef count_t num_removed = 0
@@ -104,6 +112,8 @@ cdef class Graph:
         return dereference(it).second.erase(target)
 
     cpdef int add_edge(self, node_t u, node_t v):
+        IF DEBUG_LOGGING:
+            LOGGER.info("added edge (%d, %d)", u, v)
         return self._add_directed_edge(u, v) and self._add_directed_edge(v, u)
 
     cpdef int add_edges_from(self, edge_list_t edges):
@@ -118,6 +128,8 @@ cdef class Graph:
     cpdef int remove_edge(self, node_t u, node_t v) except -1:
         if not self._remove_edge(u, v):
             raise KeyError(f"edge {(u, v)} does not exist")
+        IF DEBUG_LOGGING:
+            LOGGER.info("removed edge (%d, %d)", u, v)
 
     cpdef int remove_edges_from(self, edge_list_t edges):
         cdef count_t num_removed = 0

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ ext_modules = cythonize(
         'language_level': 3,
         'linetrace': True,
     },
+    compile_time_env={"DEBUG_LOGGING": bool(os.environ.get("DEBUG_LOGGING"))},
 )
 
 setup(

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,7 @@
 import cygraph
 import functools as ft
 import itertools as it
+import logging
 import networkx as nx
 import numbers
 import pytest
@@ -249,3 +250,23 @@ def test_views(name: str):
         attrs = [list(sorted(attr)) for attr in attrs]
     attr1, attr2 = attrs
     assert attr1 == attr2
+
+
+@pytest.mark.skipif(not cygraph.DEBUG_LOGGING, reason="debug logging not enabled")
+def test_debug_logging_add_remove_node(caplog: pytest.LogCaptureFixture):
+    graph = cygraph.Graph()
+    with caplog.at_level(logging.INFO):
+        graph.add_node(17)
+        graph.remove_node(17)
+    assert "added node 17" in caplog.text
+    assert "removed node 17" in caplog.text
+
+
+@pytest.mark.skipif(not cygraph.DEBUG_LOGGING, reason="debug logging not enabled")
+def test_debug_logging_add_remove_edge(caplog: pytest.LogCaptureFixture):
+    graph = cygraph.Graph()
+    with caplog.at_level(logging.INFO):
+        graph.add_edge(0, 7)
+        graph.remove_edge(0, 7)
+    assert "added edge (0, 7)" in caplog.text
+    assert "removed edge (0, 7)" in caplog.text


### PR DESCRIPTION
Compiling with `DEBUG_LOGGING=[some non-empty string]` will log edge and node creation at `logging.INFO` level.